### PR TITLE
3DFuse extension of Threestudio

### DIFF
--- a/custom-extensions-list.json
+++ b/custom-extensions-list.json
@@ -131,14 +131,14 @@
             "description": "Dynamic Gaussian Splatting extension of threestudio."
         },
         {
-            "author": "KU-CVLAB",
+            "author": "KU-CVLAB" ,
             "title": "threestudio-3dfuse",
             "reference": "https://github.com/KU-CVLAB/3DFuse-threestudio",
             "files": [
                 "https://github.com/KU-CVLAB/3DFuse-threestudio"
             ],
             "install_type": "git-clone",
-            "description": "3DFuse (combined with ProlificDreamer) extension of threestudio."
+            "description": "3DFuse (combined with ProlificDreamer) extension of threestudio. "
         }
     ]
 }

--- a/custom-extensions-list.json
+++ b/custom-extensions-list.json
@@ -129,6 +129,16 @@
             ],
             "install_type": "git-clone",
             "description": "Dynamic Gaussian Splatting extension of threestudio."
+        },
+        {
+            "author": "KU-CVLAB",
+            "title": "threestudio-3dfuse",
+            "reference": "https://github.com/KU-CVLAB/3DFuse-threestudio",
+            "files": [
+                "https://github.com/KU-CVLAB/3DFuse-threestudio"
+            ],
+            "install_type": "git-clone",
+            "description": "3DFuse (combined with ProlificDreamer) extension of threestudio."
         }
     ]
 }


### PR DESCRIPTION
3DFuse ("Let 2D Diffusion Model Know 3D-Consistency for Robust Text-to-3D Generation", ICLR 2024) extension of Threestudio, combined with ProlificDreamer backbone.