### PR TITLE
Adding MagicClay Extension

### DIFF
--- a/custom-extensions-list.json
+++ b/custom-extensions-list.json
@@ -150,5 +150,15 @@
             "install_type": "git-clone",
             "description": "3DFuse (combined with ProlificDreamer) extension of threestudio. "
         }
+        {
+            "author": "Amir Barda" ,
+            "title": "threestudio-magicclay",
+            "reference": "https://github.com/amirbarda/MagicClay",
+            "files": [
+                "https://github.com/amirbarda/MagicClay/tree/main/threestudio-magicclay"
+            ],
+            "install_type": "git-clone",
+            "description": "MagicClay extension of threestudio. "
+        }
     ]
 }


### PR DESCRIPTION
Hi!

I would like for my work, [MagicClay: Sculpting Meshes with Generative Neural Fields](https://amirbarda.github.io/MagicClay.github.io/) (Siggraph Asia 2024), to be registered as a threestudio extenstion.

Thanks!